### PR TITLE
Fix Jitpack using the wrong Java version

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,3 @@
-jdk:
-  - openjdk17
+before_install:
+  - sdk install java 17.0.4-tem
+  - sdk use java 17.0.4-tem


### PR DESCRIPTION
The `jdk` option in the jitpack.yml seems to not work for Java 13+ (see https://github.com/jitpack/jitpack.io/issues/4260). This changes it to use the `before_install` field, manually installing and setting the Java version to 17.

You can see [here](https://jitpack.io/com/github/Exlll/ConfigLib/v4.0.0/build.log) that #13's way of doing it causes Jitpack to still use Java 8, then fail to build.
And [here](https://jitpack.io/net/insprill/ConfigLib/fix~jitpack-67a155d3dd-1/build.log) is my way of doing it that builds successfully.