### PR TITLE
Add kebab case name formatters

### DIFF
--- a/configlib-core/src/main/java/de/exlll/configlib/NameFormatters.java
+++ b/configlib-core/src/main/java/de/exlll/configlib/NameFormatters.java
@@ -51,5 +51,51 @@ public enum NameFormatters implements NameFormatter {
             }
             return builder.toString();
         }
+    },
+    /**
+     * A {@code NameFormatter} that transforms <i>camelCase</i> to
+     * <i>lower-kebab-case</i>.
+     * <p>
+     * For example, <i>myPrivateField</i> becomes <i>my-private-field</i>.
+     */
+    LOWER_KEBAB_CASE {
+        @Override
+        public String format(String name) {
+            StringBuilder builder = new StringBuilder(name.length());
+            for (int i = 0; i < name.length(); i++) {
+                char c = name.charAt(i);
+                if (Character.isUpperCase(c)) {
+                    builder.append('-');
+                    builder.append(Character.toLowerCase(c));
+                } else {
+                    builder.append(c);
+                }
+            }
+            return builder.toString();
+        }
+    },
+    /**
+     * A {@code NameFormatter} that transforms <i>camelCase</i> to
+     * <i>UPPER-KEBAB-CASE</i>.
+     * <p>
+     * For example, <i>myPrivateField</i> becomes <i>MY-PRIVATE-FIELD</i>.
+     */
+    UPPER_KEBAB_CASE {
+        @Override
+        public String format(String name) {
+            StringBuilder builder = new StringBuilder(name.length());
+            for (int i = 0; i < name.length(); i++) {
+                char c = name.charAt(i);
+                if (Character.isLowerCase(c)) {
+                    builder.append(Character.toUpperCase(c));
+                } else if (Character.isUpperCase(c)) {
+                    builder.append('-');
+                    builder.append(c);
+                } else {
+                    builder.append(c);
+                }
+            }
+            return builder.toString();
+        }
     }
 }

--- a/configlib-core/src/test/java/de/exlll/configlib/NameFormattersTest.java
+++ b/configlib-core/src/test/java/de/exlll/configlib/NameFormattersTest.java
@@ -44,4 +44,26 @@ class NameFormattersTest {
         assertThat(formatter.format(NAME_4), is("WITH123_NUMBER"));
         assertThat(formatter.format(NAME_5), is("WITH_$"));
     }
+
+    @Test
+    void formatLowerKebab() {
+        NameFormatters formatter = NameFormatters.LOWER_KEBAB_CASE;
+
+        assertThat(formatter.format(NAME_1), is("lowercase"));
+        assertThat(formatter.format(NAME_2), is("camel-case"));
+        assertThat(formatter.format(NAME_3), is("with-number123"));
+        assertThat(formatter.format(NAME_4), is("with123-number"));
+        assertThat(formatter.format(NAME_5), is("with_$"));
+    }
+
+    @Test
+    void formatUpperKebab() {
+        NameFormatters formatter = NameFormatters.UPPER_KEBAB_CASE;
+
+        assertThat(formatter.format(NAME_1), is("LOWERCASE"));
+        assertThat(formatter.format(NAME_2), is("CAMEL-CASE"));
+        assertThat(formatter.format(NAME_3), is("WITH-NUMBER123"));
+        assertThat(formatter.format(NAME_4), is("WITH123-NUMBER"));
+        assertThat(formatter.format(NAME_5), is("WITH_$"));
+    }
 }


### PR DESCRIPTION
Adds default `NameFormatters` for `lower-kebab-case` and `UPPER-KEBAB-CASE` since they're pretty common styles.