### PR TITLE
Properly handle multi-line comments split with the newline character

### DIFF
--- a/configlib-core/src/main/java/de/exlll/configlib/CommentNodeExtractor.java
+++ b/configlib-core/src/main/java/de/exlll/configlib/CommentNodeExtractor.java
@@ -95,7 +95,9 @@ final class CommentNodeExtractor {
             final Deque<String> elementNameStack
     ) {
         if (element.isAnnotationPresent(Comment.class)) {
-            final var comments = Arrays.stream(element.getAnnotation(Comment.class).value()).flatMap(s -> Arrays.stream(s.split("\n"))).toList();
+            final var comments = Arrays.stream(element.getAnnotation(Comment.class).value())
+                    .flatMap(s -> Arrays.stream(s.split("\n", -1)))
+                    .toList();
             final var formattedName = nameFormatter.format(elementName);
             final var elementNames = new ArrayList<>(elementNameStack);
             elementNames.add(formattedName);

--- a/configlib-core/src/main/java/de/exlll/configlib/CommentNodeExtractor.java
+++ b/configlib-core/src/main/java/de/exlll/configlib/CommentNodeExtractor.java
@@ -95,11 +95,11 @@ final class CommentNodeExtractor {
             final Deque<String> elementNameStack
     ) {
         if (element.isAnnotationPresent(Comment.class)) {
-            final var comments = element.getAnnotation(Comment.class).value();
+            final var comments = Arrays.stream(element.getAnnotation(Comment.class).value()).flatMap(s -> Arrays.stream(s.split("\n"))).toList();
             final var formattedName = nameFormatter.format(elementName);
             final var elementNames = new ArrayList<>(elementNameStack);
             elementNames.add(formattedName);
-            final var result = new CommentNode(Arrays.asList(comments), elementNames);
+            final var result = new CommentNode(comments, elementNames);
             return Optional.of(result);
         }
         return Optional.empty();

--- a/configlib-core/src/test/java/de/exlll/configlib/CommentNodeExtractorTest.java
+++ b/configlib-core/src/test/java/de/exlll/configlib/CommentNodeExtractorTest.java
@@ -71,6 +71,88 @@ class CommentNodeExtractorTest {
     }
 
     @Test
+    void extractSingleCommentMultipleLines() {
+        @Configuration
+        class A {
+            @Comment("""
+                    Hello
+                    World""")
+            int i;
+        }
+
+        Queue<CommentNode> nodes = EXTRACTOR.extractCommentNodes(new A());
+        assertEquals(cn(List.of("Hello", "World"), "i"), nodes.poll());
+        assertTrue(nodes.isEmpty());
+    }
+
+    @Test
+    void extractSingleCommentMultipleLinesTrailingNewlines() {
+        @Configuration
+        class A {
+
+            @Comment("""
+                    
+                    
+                    Hello
+                    
+                    World
+                    
+                    
+                    """)
+            int i;
+
+        }
+
+        Queue<CommentNode> nodes = EXTRACTOR.extractCommentNodes(new A());
+        assertEquals(cn(List.of("", "", "Hello", "", "World", "", "", ""), "i"), nodes.poll());
+        assertTrue(nodes.isEmpty());
+    }
+
+    @Test
+    void extractSingleCommentMultipleLinesInArrayAndNewlineSplit() {
+        @Configuration
+        class A {
+
+            @Comment({ """
+                    Hello
+                    World""", """
+                    Hi
+                    Again""" })
+            int i;
+
+        }
+
+        Queue<CommentNode> nodes = EXTRACTOR.extractCommentNodes(new A());
+        assertEquals(cn(List.of("Hello", "World", "Hi", "Again"), "i"), nodes.poll());
+        assertTrue(nodes.isEmpty());
+    }
+
+    @Test
+    void extractSingleCommentMultipleLinesInArrayAndNewlineSplitWithTrailingNewlines() {
+        @Configuration
+        class A {
+
+            @Comment({ """
+                    
+                    Hello
+                    World
+                    
+                    """, """
+                    
+                    Hi
+                    Again
+                    
+                    """ })
+            int i;
+
+        }
+
+        Queue<CommentNode> nodes = EXTRACTOR.extractCommentNodes(new A());
+        assertEquals(cn(List.of("", "Hello", "World", "", "", "", "Hi", "Again", "", ""), "i"), nodes.poll());
+        assertTrue(nodes.isEmpty());
+    }
+
+    @Test
     void extractMultipleComments() {
         @Configuration
         class A {


### PR DESCRIPTION
When using the `@Comment` annotation, splitting multiple lines with `\n` causes the first part of the line to be commented, but the rest not.

Example:
```java
@Comment("line1\nline2")
private String foo = "bar";
```
```yaml
# line1
line2
foo: "bar"
```

This is especially a problem when using Java 15's text blocks as so
```java
@Comment("""
         line1
         line2
         """)
private String foo = "bar";
```

This PR simply splits each array element on `\n` and puts the array back together.