### PR TITLE
Prevent NPE in tryCreateParentDirectories

### DIFF
--- a/configlib-yaml/src/main/java/de/exlll/configlib/YamlConfigurationStore.java
+++ b/configlib-yaml/src/main/java/de/exlll/configlib/YamlConfigurationStore.java
@@ -89,9 +89,9 @@ public final class YamlConfigurationStore<T> implements
         yamlFileWriter.writeYaml(dumpedYaml, extractedCommentNodes);
     }
 
-    private void tryCreateParentDirectories(Path configurationFile) {
+    void tryCreateParentDirectories(Path configurationFile) {
         Path parent = configurationFile.getParent();
-        if (!Files.exists(parent) && properties.createParentDirectories()) {
+        if (properties.createParentDirectories() && parent != null && !Files.exists(parent)) {
             try {
                 Files.createDirectories(parent);
             } catch (IOException e) {

--- a/configlib-yaml/src/test/java/de/exlll/configlib/YamlConfigurationStoreTest.java
+++ b/configlib-yaml/src/test/java/de/exlll/configlib/YamlConfigurationStoreTest.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -570,8 +569,7 @@ class YamlConfigurationStoreTest {
                 properties
         );
 
-        Path path = Paths.get("config.yml");
-        store.tryCreateParentDirectories(path);
+        Path path = fs.getPath("config.yml");
         assertDoesNotThrow(() -> store.tryCreateParentDirectories(path));
     }
 }

--- a/configlib-yaml/src/test/java/de/exlll/configlib/YamlConfigurationStoreTest.java
+++ b/configlib-yaml/src/test/java/de/exlll/configlib/YamlConfigurationStoreTest.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -556,5 +557,21 @@ class YamlConfigurationStoreTest {
         F config = store.update(yamlFile);
         assertThat(config.s, is("S2"));
         assertThat(config.i, is(10));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void tryCreateParentDirectoriesDoesNotThrowIfParentIsNull(boolean createParentDirectories) {
+        YamlConfigurationProperties properties = YamlConfigurationProperties.newBuilder()
+                .createParentDirectories(createParentDirectories)
+                .build();
+        YamlConfigurationStore<A> store = new YamlConfigurationStore<>(
+                A.class,
+                properties
+        );
+
+        Path path = Paths.get("config.yml");
+        store.tryCreateParentDirectories(path);
+        assertDoesNotThrow(() -> store.tryCreateParentDirectories(path));
     }
 }


### PR DESCRIPTION
Fixes #39.

Additionally adds a test for the failure (tryCreateParentDirectories was made package-private for this purpose).