### PR TITLE
Mark as folia supported

### DIFF
--- a/configlib-paper/src/main/resources/plugin.yml
+++ b/configlib-paper/src/main/resources/plugin.yml
@@ -5,3 +5,4 @@ description: A library for working with YAML configurations.
 author: Exlll
 main: de.exlll.configlib.ConfigLib
 api-version: 1.19
+folia-supported: true


### PR DESCRIPTION
Mark the paper plugin.yml as `folia-supported` to allow compatibility with [Folia](https://github.com/PaperMC/Folia).