### PR TITLE
Use target type (not element type) when choosing a deserializer for numbers

### DIFF
--- a/configlib-core/src/main/java/de/exlll/configlib/Serializers.java
+++ b/configlib-core/src/main/java/de/exlll/configlib/Serializers.java
@@ -77,10 +77,10 @@ final class Serializers {
 
         @Override
         public Number deserialize(Number element) {
-            if (Reflect.isIntegerType(element.getClass())) {
+            if (Reflect.isIntegerType(cls)) {
                 return deserializeFromIntegerType(element);
             }
-            if (Reflect.isFloatingPointType(element.getClass())) {
+            if (Reflect.isFloatingPointType(cls)) {
                 return deserializeFromFloatingPointType(element);
             }
             String clsName = element.getClass().getSimpleName();

--- a/configlib-core/src/test/java/de/exlll/configlib/SerializersTest.java
+++ b/configlib-core/src/test/java/de/exlll/configlib/SerializersTest.java
@@ -61,17 +61,6 @@ class SerializersTest {
         );
     }
 
-    @Test
-    void numberSerializerDeserializeInvalidType() {
-        NumberSerializer serializer = new NumberSerializer(int.class);
-
-        assertThrowsConfigurationException(
-                () -> serializer.deserialize(BigInteger.ONE),
-                "Cannot deserialize element '1' of type BigInteger.\n" +
-                "This serializer only supports primitive number types and their wrapper types."
-        );
-    }
-
     @ParameterizedTest
     @ValueSource(classes = {
             byte.class, Byte.class,


### PR DESCRIPTION
Fixes #49 