### PR TITLE
Use Locale.ROOT for toLowerCase/toUpperCase calls

### DIFF
--- a/configlib-core/src/main/java/de/exlll/configlib/RootSerializer.java
+++ b/configlib-core/src/main/java/de/exlll/configlib/RootSerializer.java
@@ -3,6 +3,7 @@ package de.exlll.configlib;
 import de.exlll.configlib.ConfigurationProperties.EnvVarResolutionConfiguration;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -86,7 +87,7 @@ final class RootSerializer<T> implements Serializer<T, Map<?, ?>> {
                         : prefix + '_' + key;
                 envVar = envVarConfig.caseSensitive()
                         ? envVar
-                        : envVar.toUpperCase();
+                        : envVar.toUpperCase(Locale.ROOT);
                 final String envVarVal = environment.getValue(envVar);
                 preprocessRecursively(val, envVar, envVarVal, entry::setValue);
             }
@@ -100,7 +101,7 @@ final class RootSerializer<T> implements Serializer<T, Map<?, ?>> {
                         : prefix + '_' + i;
                 envVar = envVarConfig.caseSensitive()
                         ? envVar
-                        : envVar.toUpperCase();
+                        : envVar.toUpperCase(Locale.ROOT);
                 final String envVarVal = environment.getValue(envVar);
                 final int index = i;
                 preprocessRecursively(val, envVar, envVarVal, o -> list.set(index, o));

--- a/configlib-core/src/main/java/de/exlll/configlib/Serializers.java
+++ b/configlib-core/src/main/java/de/exlll/configlib/Serializers.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.Locale;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;

--- a/configlib-core/src/main/java/de/exlll/configlib/Serializers.java
+++ b/configlib-core/src/main/java/de/exlll/configlib/Serializers.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.Locale;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -264,7 +265,7 @@ public final class Serializers {
                     .formatted(
                             sourceTypeName,
                             value,
-                            sourceTypeName.toLowerCase(),
+                            sourceTypeName.toLowerCase(Locale.ROOT),
                             coercionType
                     );
         }

--- a/configlib-core/src/test/java/de/exlll/configlib/SerializersTest.java
+++ b/configlib-core/src/test/java/de/exlll/configlib/SerializersTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.Locale;
 
 import static de.exlll.configlib.TestUtils.*;
 import static java.util.Arrays.asList;
@@ -1111,7 +1112,7 @@ class SerializersTest {
                    %s '%s' cannot be deserialized to type String because %s-to-string \
                    coercion has not been configured. If you want to allow this type of coercion, \
                    add the deserialization coercion type '%s' via a ConfigurationProperties object.\
-                   """.formatted(sourceTypeName, value, sourceTypeName.toLowerCase(), deserializationCoercingType);
+                   """.formatted(sourceTypeName, value, sourceTypeName.toLowerCase(Locale.ROOT), deserializationCoercingType);
         }
 
         @Test

--- a/configlib-core/src/test/java/de/exlll/configlib/SerializersTest.java
+++ b/configlib-core/src/test/java/de/exlll/configlib/SerializersTest.java
@@ -20,7 +20,6 @@ import java.nio.file.Path;
 import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.Locale;
 
 import static de.exlll.configlib.TestUtils.*;
 import static java.util.Arrays.asList;


### PR DESCRIPTION
## Summary

- Replaced all bare `toLowerCase()` and `toUpperCase()` calls with `toLowerCase(Locale.ROOT)` / `toUpperCase(Locale.ROOT)` across `Serializers.java`, `RootSerializer.java`, and `SerializersTest.java`.

## Why This Is Needed

Java's `String.toLowerCase()` and `String.toUpperCase()` without a `Locale` argument use `Locale.getDefault()`, which is derived from the system/JVM locale. This means the **same code can produce different results** on different machines depending on the OS locale settings.

The most well-known problem is with the **Turkish locale** (`tr_TR`), where:

| Expression | `Locale.ENGLISH` / `Locale.ROOT` | `Locale("tr", "TR")` |
|---|---|---|
| `"INTEGER".toLowerCase()` | `"integer"` | `"ınteger"` (dotless ı) |
| `"integer".toUpperCase()` | `"INTEGER"` | `"İNTEGER"` (dotted İ) |
| `"I".toLowerCase()` | `"i"` | `"ı"` |
| `"i".toUpperCase()` | `"I"` | `"İ"` |

### Concrete impact in this codebase

- **`Serializers.java`**: The error message includes `sourceTypeName.toLowerCase()` (e.g., turning `"Boolean"` into `"boolean"` for the phrase `"boolean-to-string coercion"`). On a Turkish-locale system, `"Boolean"` would become `"boolean"` correctly, but type names containing `I` (like `"BigInteger"`) would become `"bıgınteger"` — a garbled error message.

- **`RootSerializer.java`**: Environment variable names are uppercased with `toUpperCase()`. On a Turkish-locale system, a key containing `"i"` would be converted to `"İ"` (with a dot above) instead of `"I"`, causing environment variable lookups to silently **fail to match** the actual env var.

### Examples of real-world breakage

```java
// On a Turkish-locale JVM:
"myAppConfig_item".toUpperCase()
// Expected: "MYAPPCONFIG_ITEM"
// Actual:   "MYAPPCONFIG_İTEM"  ← env var lookup will fail!

"Integer".toLowerCase()
// Expected: "integer"
// Actual:   "ınteger"  ← broken error message
```

`Locale.ROOT` is the correct choice here (rather than `Locale.ENGLISH`) because these are **programmatic/technical strings**, not user-facing text that needs language-specific rules. `Locale.ROOT` provides locale-independent behavior, which is exactly what's needed for identifiers, env var names, and type names.

## Test plan

- [x] Verified no remaining bare `toLowerCase()`/`toUpperCase()` calls in the codebase
- [ ] Existing tests should continue to pass since behavior is unchanged on non-Turkish locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)