### PR TITLE
fix(core): resolve kebab env vars as snake case

### DIFF
--- a/configlib-core/src/main/java/de/exlll/configlib/RootSerializer.java
+++ b/configlib-core/src/main/java/de/exlll/configlib/RootSerializer.java
@@ -82,12 +82,7 @@ final class RootSerializer<T> implements Serializer<T, Map<?, ?>> {
                 final Object key = entry.getKey();
                 if (key == null) continue;
                 final Object val = entry.getValue();
-                String envVar = prefix.isEmpty()
-                        ? key.toString()
-                        : prefix + '_' + key;
-                envVar = envVarConfig.caseSensitive()
-                        ? envVar
-                        : envVar.toUpperCase(Locale.ROOT);
+                String envVar = createEnvironmentVariable(prefix, key.toString());
                 final String envVarVal = environment.getValue(envVar);
                 preprocessRecursively(val, envVar, envVarVal, entry::setValue);
             }
@@ -96,16 +91,21 @@ final class RootSerializer<T> implements Serializer<T, Map<?, ?>> {
         private void preprocessEnvVarList(String prefix, List<Object> list) {
             for (int i = 0; i < list.size(); i++) {
                 final Object val = list.get(i);
-                String envVar = prefix.isEmpty()
-                        ? String.valueOf(i)
-                        : prefix + '_' + i;
-                envVar = envVarConfig.caseSensitive()
-                        ? envVar
-                        : envVar.toUpperCase(Locale.ROOT);
+                String envVar = createEnvironmentVariable(prefix, String.valueOf(i));
                 final String envVarVal = environment.getValue(envVar);
                 final int index = i;
                 preprocessRecursively(val, envVar, envVarVal, o -> list.set(index, o));
             }
+        }
+
+        private String createEnvironmentVariable(String prefix, String pathSegment) {
+            String envVar = prefix.isEmpty()
+                    ? pathSegment
+                    : prefix + '_' + pathSegment;
+            envVar = envVar.replace('-', '_');
+            return envVarConfig.caseSensitive()
+                    ? envVar
+                    : envVar.toUpperCase(Locale.ROOT);
         }
 
         private void preprocessRecursively(

--- a/configlib-core/src/test/java/de/exlll/configlib/RootSerializerTest.java
+++ b/configlib-core/src/test/java/de/exlll/configlib/RootSerializerTest.java
@@ -47,6 +47,10 @@ class RootSerializerTest {
                 List<List<String>> listListString
         ) {}
 
+        record KebabConfig(String encryptionKey, KebabNestedConfig nestedConfig) {}
+
+        record KebabNestedConfig(int portNumber) {}
+
 
         @Test
         void preprocessEnvVarsFailsIfEnvVarTriesToReplaceCollection() {
@@ -175,6 +179,31 @@ class RootSerializerTest {
                     entry("listMapStringInteger", asList(asMap("NO", 1L, "YES", 2L))),
                     entry("listListString", asList(asList(), asList(), asList("", "TEST1")))
             )));
+        }
+
+        @Test
+        void preprocessLowerKebabEnvVarsWithSnakeCaseEnvironmentNames() {
+            final var envConfig = EnvVarResolutionConfiguration.resolveEnvVarsWithPrefix("MY_PREFIX", false);
+            final var props = ConfigurationProperties.newBuilder()
+                    .setNameFormatter(NameFormatters.LOWER_KEBAB_CASE)
+                    .setEnvVarResolutionConfiguration(envConfig)
+                    .build();
+            final var serializer = new RootSerializer<>(
+                    KebabConfig.class,
+                    props,
+                    new MapEnvironment(entriesAsMap(
+                            entry("MY_PREFIX_ENCRYPTION_KEY", "env-key"),
+                            entry("MY_PREFIX_NESTED_CONFIG_PORT_NUMBER", "5432")
+                    ))
+            );
+
+            KebabConfig config = serializer.deserialize(asMap(
+                    "encryption-key", "yaml-key",
+                    "nested-config", asMap("port-number", 3306L)
+            ));
+
+            assertThat(config.encryptionKey, is("env-key"));
+            assertThat(config.nestedConfig.portNumber, is(5432));
         }
 
         @Test

--- a/configlib-core/src/test/java/de/exlll/configlib/RootSerializerTest.java
+++ b/configlib-core/src/test/java/de/exlll/configlib/RootSerializerTest.java
@@ -47,9 +47,9 @@ class RootSerializerTest {
                 List<List<String>> listListString
         ) {}
 
-        record KebabConfig(String encryptionKey, KebabNestedConfig nestedConfig) {}
+        private record KebabConfig(String encryptionKey, KebabNestedConfig nestedConfig) {}
 
-        record KebabNestedConfig(int portNumber) {}
+        private record KebabNestedConfig(int portNumber) {}
 
 
         @Test


### PR DESCRIPTION
## Summary

- Normalize generated environment variable names by replacing dashes with underscores before lookup.
- Add a regression test for lower-kebab configuration keys resolving from snake_case environment variables.

## Why

Lower-kebab formatted config keys such as `encryption-key` previously generated environment variable names like `ENCRYPTION-KEY`, which cannot be used as normal environment variables on many systems. This keeps kebab-case config files while allowing `ENCRYPTION_KEY` style overrides.

## Validation

- `JAVA_HOME=/tmp/codex-jdk21 PATH=/tmp/codex-jdk21/bin:$PATH ./gradlew :configlib-core:check`

## Disclosure

This PR was made with Codex GPT-5.5 medium fast.
And yes this is a real bug I have in my production plugins.